### PR TITLE
AMD first

### DIFF
--- a/tooltip.js
+++ b/tooltip.js
@@ -1,8 +1,8 @@
 (function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
+    if(typeof define === 'function' && define.amd)
+        define([], factory);
+    else if(typeof module === "object" && module.exports)
 		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
 	else if(typeof exports === 'object')
 		exports["Tooltip"] = factory();
 	else


### PR DESCRIPTION
Check AMD first since it is common practice and this line appears broken in VizyDrop

http://ifandelse.com/its-not-hard-making-your-library-support-amd-and-commonjs/